### PR TITLE
Added script to deploy OVN CNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ this repo contains scripts to:
 * setup a docker registry for kind
 * start a cluster api management cluster with docker and kubemark providers
 * get kubeconfig files for kind clusters
-* deploy cni to cluster api workload clusters
+* deploy cni (Calico or OVN) to cluster api workload clusters
 * start a local cluster autoscaler
 
 and kubernetes manifests for creating various cluster api kubemark clusters.

--- a/deploy-cni-ovn.sh
+++ b/deploy-cni-ovn.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# deploy ovn cni to target cluster
+set -ex
+
+if [ -n "$1" ]
+then
+    KUBECONFIG_FLAG="--kubeconfig $1"
+else
+    KUBECONFIG_FLAG=""
+fi
+if [ -n "$2" ]
+then
+    KIND_CLUSTER_FLAG="--cn $2"
+else
+    KIND_CLUSTER_FLAG=""
+fi
+KIND_NODES=$(kind get nodes --name ovn)
+for n in $KIND_NODES; do
+    docker exec "$n" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
+    docker exec "$n" sysctl --ignore net.ipv6.conf.all.forwarding=1
+done
+if [ ! -d "ovn-kubernetes" ]
+then
+    git clone https://github.com/ovn-org/ovn-kubernetes.git
+fi
+pushd ovn-kubernetes/contrib/
+./kind.sh $KIND_CLUSTER_FLAG $KUBECONFIG_FLAG --deploy
+popd


### PR DESCRIPTION
Added a **deploy-cni-ovn.sh** script to (build and) deploy OVN.
Use:
`./deploy-cni.ovn.sh $KUBECONFIG $KIND_CLUSTER_NAME
`

Tested with:
 - Ubuntu 22.04
 - kind v0.17.0
