### PR TITLE
fix: remove extra comma in KubeadmControlPlane example spec

### DIFF
--- a/kubemark/kubemark-workload-control-plane.yaml
+++ b/kubemark/kubemark-workload-control-plane.yaml
@@ -53,7 +53,7 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
-        - 0.0.0.0,
+        - 0.0.0.0
         - host.docker.internal
     initConfiguration: {}
     joinConfiguration: {}


### PR DESCRIPTION
Removes a trailing comma, which apparently was the reason why bootstrapping failed when you do:
```
kubectl create -f kubemark/kubemark-workload-control-plane.yaml
```
after going through all the setup with kubemark cluster-api.

Looks normal now:
```bash
┌─[macao@ubuntu-vm]─(~/capi-hacks)(devel U:2 ✗)
└─[04:05]-(^_^)-[$] clusterctl describe cluster kubemark-workload
NAME                                                                  READY  SEVERITY  REASON  SINCE  MESSAGE 
Cluster/kubemark-workload                                             True                     4m58s           
├─ClusterInfrastructure - DockerCluster/kubemark-workload             True                     5m28s           
└─ControlPlane - KubeadmControlPlane/kubemark-workload-control-plane  True                     4m58s           
  └─Machine/kubemark-workload-control-plane-qnpd5                     True                     5m  
```