### PR TITLE
fix karpenter kubemark example manifests

### DIFF
--- a/karpenter/km-wl-kubemark-md-1.yaml
+++ b/karpenter/km-wl-kubemark-md-1.yaml
@@ -13,11 +13,6 @@ metadata:
     node.cluster.x-k8s.io/karpenter-member: ""
   name: km-wl-kubemark-md-1
   namespace: default
-  ownerReferences:
-  - apiVersion: cluster.x-k8s.io/v1beta1
-    kind: Cluster
-    name: km-cp
-    uid: a834de54-29c1-48d4-840d-246a582ba8f0
 spec:
   clusterName: km-cp
   minReadySeconds: 0
@@ -55,7 +50,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: KubemarkMachineTemplate
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: kubemark-workload
+    cluster.x-k8s.io/cluster-name: km-cp
   name: km-wl-kubemark-md-1
   namespace: default
 spec:


### PR DESCRIPTION
Removes the ownerReference in the machinedeployment because if you apply it, it gets instantly deleted since that cluster with that exact uid probably won't exist in your environment. I'm assuming the capk controller is the thing that handles applying the ownerReference to the md, so we can just let that happen.

Also renames some cluster-name label to match up with all the other labels that are referencing a cluster name.